### PR TITLE
Add the path parameter to autospy schematic

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,11 @@
+0.8.4 Fix [issue #30](https://github.com/gparlakov/scuri/issues/30) - autospy schematic accepts `path` to tell it where to __place__ the created file
+
 0.8.3 Fix the missing autospy files
+
 0.8.2 Release with only doc changes - no other changes. Required to update the doc on https://www.npmjs.com/package/scuri site.
+
 0.8.1 Release with only doc changes - no other changes. Required to update the doc on https://www.npmjs.com/package/scuri site.
+
 0.8.0 AutoSpy create schematic. Support for jasmine and jest. As well as ts 2.8 and previous(legacy). To use:
 ``` schematics scuri:autospy ``` - for angular 5 and previous
 ``` ng g scuri:autospy ``` for angular 6 and up
@@ -9,6 +14,7 @@ Both cases requires `npm i scuri` (or `npm i -g scuri`) and the first requires `
 0.7.0 (and 0.6.2) Import dependencies when including them in the spec-s. Both for Create and Update
 
 0.6.1 Actually have all required deps and build the js...
+
 0.6.0 Make all unneeded dependencies devDependencies to avoid clashing and breaking users. All we need is the devkit core and the rest is dev-time dependency only
 
 0.5.0 Support for updating the spec to test out the new methods part of the class. Case - add one more method to the class - run scuri update (via [scuri-code](https://marketplace.visualstudio.com/items?itemName=gparlakov.scuri-code) or the command line)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scuri",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "A spec generator schematic - Spec Create Update Read (class - component, service, directive and dependencies) Incorporate (them in the result)",
   "scripts": {
     "s": "schematics",
@@ -8,10 +8,10 @@
     "build": "tsc -p tsconfig.json",
     "build.test": "tsc -p tsconfig.test.json",
     "test": "npm run build.test && jasmine tests/**/*_spec.js",
+    "test.watch": "chokidar \"src/**/*.ts\" \"tests/**/*.ts\" -c \"npm test\" --initial --ignore \"src/**/*.d.ts\" --ignore \"tests/**/*.d.ts\"",
     "build.run": "npm run build && npm run s .:spec -- --name ./example/example.component.ts",
-    "watch": "chokidar \"src/**/*.ts\" -c \"npm start\" --initial --ignore \"src/**/*.d.ts\"",
-    "watch.build.run": "chokidar \"src/**/*.ts\" -c \"npm run build.run\" --initial --ignore \"src/**/*.d.ts\"",
-    "watch.test": "chokidar \"src/**/*.ts\" \"tests/**/*.ts\" -c \"npm test\" --initial --ignore \"src/**/*.d.ts\" --ignore \"tests/**/*.d.ts\"",
+    "start.watch": "chokidar \"src/**/*.ts\" -c \"npm start\" --initial --ignore \"src/**/*.d.ts\"",
+    "build.run.watch": "chokidar \"src/**/*.ts\" -c \"npm run build.run\" --initial --ignore \"src/**/*.d.ts\"",
     "tslint": "tslint",
     "lint": "npm run tslint -- -p tsconfig.test.json -c tslint.json",
     "pretty-quick": "pretty-quick",

--- a/src/autospy/index.ts
+++ b/src/autospy/index.ts
@@ -1,8 +1,18 @@
-import { apply, applyTemplates, mergeWith, Rule, SchematicContext, Tree, url } from '@angular-devkit/schematics';
+import {
+    apply,
+    applyTemplates,
+    mergeWith,
+    Rule,
+    SchematicContext,
+    Tree,
+    url,
+    move
+} from '@angular-devkit/schematics';
 
 export class AutoSpyOptions {
     for: 'jasmine' | 'jest' = 'jasmine';
     legacy?: boolean = false;
+    path: string = '.';
 }
 
 export default function(options: AutoSpyOptions): Rule {
@@ -10,7 +20,7 @@ export default function(options: AutoSpyOptions): Rule {
         const runner = options.for;
         const v = options.legacy ? '-ts-2.7' : '';
 
-        const source = apply(url(`./files/${runner}${v}`), [applyTemplates({})]);
+        const source = apply(url(`./files/${runner}${v}`), [applyTemplates({}), move(options.path)]);
         return mergeWith(source);
     };
 }

--- a/src/autospy/schema.json
+++ b/src/autospy/schema.json
@@ -14,6 +14,11 @@
       "type": "boolean",
       "default": false,
       "description": "For generating autoSpy compatible with using older than typescript 2.8 (for conditional types. Details: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html) "
+    },
+    "path": {
+      "type": "string",
+      "description": "Where to create the auto-spy.ts at",
+      "default": "."
     }
   }
 }

--- a/tests/autospy/index_spec.ts
+++ b/tests/autospy/index_spec.ts
@@ -18,6 +18,13 @@ describe('spec', () => {
         expect(res.files[0]).toEqual('/auto-spy.ts');
     });
 
+    it('creates one file at given path - auto-spy.ts', () => {
+        const runner = new SchematicTestRunner('schematics', collectionPath);
+        const res = runner.runSchematic('autospy', { path: './folder/' }, tree);
+        expect(res.files.length).toBe(1);
+        expect(res.files[0]).toEqual('/folder/auto-spy.ts');
+    });
+
     it('creates jasmine-style auto-spy by default', () => {
         const runner = new SchematicTestRunner('schematics', collectionPath);
         const res = runner.runSchematic('autospy', {}, tree);
@@ -65,7 +72,6 @@ describe('spec', () => {
             expect(generatedContent).not.toMatch('T[k] extends');
             expect(generatedContent).toMatch('export function autoSpy');
         });
-
 
         it('creates jest-style auto-spy with `--for jest` without using conditional types', () => {
             const runner = new SchematicTestRunner('schematics', collectionPath);


### PR DESCRIPTION
Add the `path` parameter to autospy schematic allowing user to select where to place the created `auto-spy.ts`

Closes #30 