### PR TITLE
Use both object.keys and .getOwnPropertyNames

### DIFF
--- a/src/autospy/files/jasmine-ts-2.7/auto-spy.ts.template
+++ b/src/autospy/files/jasmine-ts-2.7/auto-spy.ts.template
@@ -2,7 +2,9 @@
 export function autoSpy<T>(obj: new (...args: any[]) => T): SpyOf<T> {
     const res: SpyOf<T> = {} as any;
 
-    Object.keys(obj.prototype).forEach(key => {
+    // turns out that in target:es2015 the methods attached to the prototype are not enumerable so Object.keys returns []. So to workaround that and keep some backwards compatibility - merge with ownPropertyNames - that disregards the enumerable property.
+    const keys = [...Object.keys(obj.prototype), ...Object.getOwnPropertyNames(obj.prototype)];
+    keys.forEach(key => {
         res[key] = jasmine.createSpy(key);
     });
 

--- a/src/autospy/files/jasmine/auto-spy.ts.template
+++ b/src/autospy/files/jasmine/auto-spy.ts.template
@@ -2,7 +2,9 @@
 export function autoSpy<T>(obj: new (...args: any[]) => T): SpyOf<T> {
     const res: SpyOf<T> = {} as any;
 
-    Object.keys(obj.prototype).forEach(key => {
+    // turns out that in target:es2015 the methods attached to the prototype are not enumerable so Object.keys returns []. So to workaround that and keep some backwards compatibility - merge with ownPropertyNames - that disregards the enumerable property.
+    const keys = [...Object.keys(obj.prototype), ...Object.getOwnPropertyNames(obj.prototype)];
+    keys.forEach(key => {
         res[key] = jasmine.createSpy(key);
     });
 

--- a/src/autospy/files/jest-ts-2.7/auto-spy.ts.template
+++ b/src/autospy/files/jest-ts-2.7/auto-spy.ts.template
@@ -2,8 +2,10 @@
 export function autoSpy<T>(obj: new (...args: any[]) => T): SpyOf<T> {
     const res: SpyOf<T> = {} as any;
 
-    Object.keys(obj.prototype).forEach(key => {
-        res[key] = jest.fn();
+    // turns out that in target:es2015 the methods attached to the prototype are not enumerable so Object.keys returns []. So to workaround that and keep some backwards compatibility - merge with ownPropertyNames - that disregards the enumerable property.
+    const keys = [...Object.keys(obj.prototype), ...Object.getOwnPropertyNames(obj.prototype)];
+    keys.forEach(key => {
+        res[key] = jasmine.createSpy(key);
     });
 
     return res;

--- a/src/autospy/files/jest-ts-2.7/auto-spy.ts.template
+++ b/src/autospy/files/jest-ts-2.7/auto-spy.ts.template
@@ -5,7 +5,7 @@ export function autoSpy<T>(obj: new (...args: any[]) => T): SpyOf<T> {
     // turns out that in target:es2015 the methods attached to the prototype are not enumerable so Object.keys returns []. So to workaround that and keep some backwards compatibility - merge with ownPropertyNames - that disregards the enumerable property.
     const keys = [...Object.keys(obj.prototype), ...Object.getOwnPropertyNames(obj.prototype)];
     keys.forEach(key => {
-        res[key] = jasmine.createSpy(key);
+        res[key] = jest.fn();
     });
 
     return res;

--- a/src/autospy/files/jest/auto-spy.ts.template
+++ b/src/autospy/files/jest/auto-spy.ts.template
@@ -2,8 +2,10 @@
 export function autoSpy<T>(obj: new (...args: any[]) => T): SpyOf<T> {
     const res: SpyOf<T> = {} as any;
 
-    Object.keys(obj.prototype).forEach(key => {
-        res[key] = jest.fn();
+    // turns out that in target:es2015 the methods attached to the prototype are not enumerable so Object.keys returns []. So to workaround that and keep some backwards compatibility - merge with ownPropertyNames - that disregards the enumerable property.
+    const keys = [...Object.keys(obj.prototype), ...Object.getOwnPropertyNames(obj.prototype)];
+    keys.forEach(key => {
+        res[key] = jasmine.createSpy(key);
     });
 
     return res;

--- a/src/autospy/files/jest/auto-spy.ts.template
+++ b/src/autospy/files/jest/auto-spy.ts.template
@@ -5,7 +5,7 @@ export function autoSpy<T>(obj: new (...args: any[]) => T): SpyOf<T> {
     // turns out that in target:es2015 the methods attached to the prototype are not enumerable so Object.keys returns []. So to workaround that and keep some backwards compatibility - merge with ownPropertyNames - that disregards the enumerable property.
     const keys = [...Object.keys(obj.prototype), ...Object.getOwnPropertyNames(obj.prototype)];
     keys.forEach(key => {
-        res[key] = jasmine.createSpy(key);
+        res[key] = jest.fn();
     });
 
     return res;


### PR DESCRIPTION
In es2015 the methods attached to the prototype are not enumberable so Object.keys misses them

#closes #55 