### PR TITLE
fix: change all lowercase to camelCase

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Using VS Code? Just install the [**SCuri** VS Code extension](https://marketplac
 
     [Details and older Angular versions](#autospy-1)
 
-3. Tell **Typescript** where to find `autospy` by adding `autospy` to `paths`:
+3. Tell **Typescript** where to find `autoSpy` by adding `autoSpy` to `paths`:
 
     ```json
     {
@@ -95,7 +95,7 @@ Using VS Code? Just install the [**SCuri** VS Code extension](https://marketplac
             ...
             "baseUrl": ".",
             "paths": {
-                "autospy": ["./src/auto-spy"]
+                "autoSpy": ["./src/auto-spy"]
             }
         }
     }


### PR DESCRIPTION
The generated `.spec.ts` files are importing from a camel-cased `autoSpy`:

~~~ts
import { autoSpy } from 'autoSpy';
~~~

However, the instructions in the `README.md` are using all lowercase:

~~~json
        "paths": {
            "autospy": ["./src/auto-spy"] // This mapping is relative to "baseUrl"
        }
~~~

BTW: Thanks for the project, I hope it will enable me as a single-frontend developer to actually write those long intended angular unit tests. 