### PR TITLE
feat: fill in Promise and Observables

### DIFF
--- a/src/common/get-spec-file-name.ts
+++ b/src/common/get-spec-file-name.ts
@@ -15,21 +15,21 @@ export function getSpecFileCustomName(
 ): string | undefined {
     const templateFile: FileEntry = {
         path: basename(normalize(templateName)),
-        content: Buffer.from('')
+        content: Buffer.from(''),
     };
 
     const fileResult = applyPathTemplate(classData)(templateFile);
 
-    const folderfyFn = folderfy(classData.folder)
+    const folderfyFn = folderfy(classData.folder);
 
     return typeof fileResult?.path === 'string'
-        ? folderfyFn(fileResult.path
-            // remove template if any
-            .replace(TEMPLATE_FILENAME_RE, '')
-        )
+        ? folderfyFn(
+              fileResult.path
+                  // remove template if any
+                  .replace(TEMPLATE_FILENAME_RE, '')
+          )
         : undefined;
-} 
-
+}
 
 function folderfy(folder: string) {
     return (fileName: string) => {
@@ -38,6 +38,6 @@ function folderfy(folder: string) {
             fileName
                 // remove the path as a possible duplicate
                 .replace(folder, '')
-        )
-    }
+        );
+    };
 }

--- a/src/common/print-node.ts
+++ b/src/common/print-node.ts
@@ -4,7 +4,7 @@ import * as ts from 'typescript';
 export function printKindAndText(node?: ts.Node[] | ts.Node | null, printOutSpaces = false) {
     if (node != null) {
         if (Array.isArray(node)) {
-            node.forEach(n => printKindAndText(n, printOutSpaces));
+            node.forEach((n) => printKindAndText(n, printOutSpaces));
         } else {
             // tslint:disable-next-line:no-console
             console.log(
@@ -20,13 +20,17 @@ export function printKindAndText(node?: ts.Node[] | ts.Node | null, printOutSpac
     }
 }
 let depth = 1;
-let maxDepth = 5;
+let maxDepthDefault = 5;
 
-
-export function printKindAndTextRecursive(node?: ts.Node[] | ts.Node | null, printOutSpaces = false) {
+export function printKindAndTextRecursive(
+    node?: ts.Node[] | ts.Node | null,
+    printOutSpaces = false,
+    options?: { maxDepth?: number }
+) {
+    const maxDepth = options?.maxDepth == null || isNaN(options?.maxDepth) ? maxDepthDefault : options?.maxDepth;
     if (node != null) {
         if (Array.isArray(node)) {
-            node.forEach(c => printKindAndTextRecursive(c, printOutSpaces));
+            node.forEach((c) => printKindAndTextRecursive(c, printOutSpaces, options));
         } else {
             // tslint:disable-next-line:no-console
             console.log(
@@ -41,7 +45,7 @@ export function printKindAndTextRecursive(node?: ts.Node[] | ts.Node | null, pri
             depth += 1;
             const children = node.getChildren();
             if (Array.isArray(children) && depth <= maxDepth) {
-                printKindAndTextRecursive(children, printOutSpaces);
+                printKindAndTextRecursive(children, printOutSpaces, options);
             }
             depth -= 1;
         }
@@ -50,7 +54,6 @@ export function printKindAndTextRecursive(node?: ts.Node[] | ts.Node | null, pri
         console.log('this is empty');
     }
 }
-
 
 function _formatTextWithSpaces(node: ts.Node | string, printOutSpaces: boolean) {
     const text = typeof node === 'string' ? node : node.getFullText();

--- a/src/spec/files/class/__specFileName__.template
+++ b/src/spec/files/class/__specFileName__.template
@@ -1,6 +1,7 @@
 <% params.forEach(p => { if(p.importPath) {%>import { <%= p.type %> } from '<%= p.importPath %>';
 <% }}) %>import { <%= className %> } from './<%= normalizedName %>';
 import { autoSpy } from 'autoSpy';
+import { EMPTY } from 'rxjs';
 
 describe('<%= className %>', () => {
   <% publicMethods.forEach(meth=> {if(meth != '') { %>it('when <%= meth %> is called it should', () => {

--- a/src/spec/index.ts
+++ b/src/spec/index.ts
@@ -15,7 +15,7 @@ import {
 } from '@angular-devkit/schematics';
 import { cosmiconfigSync } from 'cosmiconfig';
 import { EOL } from 'os';
-import { join, resolve } from 'path';
+import { resolve } from 'path';
 import { Change, InsertChange, RemoveChange } from '../../lib/utility/change';
 import { getSpecFilePathName } from '../common/get-spec-file-name';
 import { paths } from '../common/paths';
@@ -220,8 +220,7 @@ function createNewSpec(
                 declaration: toDeclaration(),
                 builderExports: toBuilderExports(),
                 constructorParams: toConstructorParams(),
-                shorthand: typeShorthand(name),
-                depsCallsAndTypes
+                shorthand: typeShorthand(name)
             };
             const src = maybeUseCustomTemplate(tree, url('./files/class'), o?.classTemplate);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,11 +8,17 @@ import {
     underscore,
 } from '@angular-devkit/core/src/utils/strings';
 
+export type DepType = string & {___type?: 'DepType'};
+export type MethodName = string & {___type?: 'MethodName'}; ;
+export type ReturnType = string & {___type?: 'ReturnType'};
+
 export type ClassDescription = {
     type: 'class';
     name: string;
     constructorParams: ConstructorParam[];
     publicMethods: string[];
+
+    depsCallsAndTypes?: Map<DepType, Map<MethodName, ReturnType>>;
 };
 
 export type ConstructorParam = {
@@ -104,6 +110,8 @@ export type ClassTemplateData = StringsFunctions & {
     declaration: string;
 
     builderExports: string;
+
+    depsCallsAndTypes?: ClassDescription['depsCallsAndTypes'];
 };
 
 type StringsFunctions = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -110,8 +110,6 @@ export type ClassTemplateData = StringsFunctions & {
     declaration: string;
 
     builderExports: string;
-
-    depsCallsAndTypes?: ClassDescription['depsCallsAndTypes'];
 };
 
 type StringsFunctions = {

--- a/tests/spec/all.deps-calls-with-return-types.spec.ts
+++ b/tests/spec/all.deps-calls-with-return-types.spec.ts
@@ -1,0 +1,30 @@
+import { describeSource } from '../../src/common/read/read';
+import { ClassDescription } from '../../src/types';
+import { depsCallsReturnTypesFile, depsCallsReturnTypesFileContents } from './common';
+
+describe('Dependency method calls ', () => {
+    it('should read the names and return types of dependency methods', async () => {
+        const fileName = depsCallsReturnTypesFile;
+        // arrange
+        const x = describeSource(fileName, depsCallsReturnTypesFileContents());
+        // act
+        const classDescription: ClassDescription = x[0] as ClassDescription;
+
+        // assert
+        expect(classDescription.depsCallsAndTypes).toBeDefined();
+
+        const returnTypes = classDescription.depsCallsAndTypes;
+        expect(returnTypes).toEqual(
+            new Map([
+                [
+                    'ServiceWithMethods',
+                    new Map([
+                        ['justAMethod', 'ClassDescription'],
+                        ['observableReturning', 'Observable<string>'],
+                        ['promiseReturning', 'Promise<string>'],
+                    ]),
+                ],
+            ])
+        );
+    });
+});

--- a/tests/spec/common.ts
+++ b/tests/spec/common.ts
@@ -1,3 +1,8 @@
-import * as path from 'path';
+import { join } from 'path';
+import { readFileSync } from 'fs';
 
-export const collectionPath = path.join(__dirname, '../../src/collection.json');
+export const collectionPath = join(__dirname, '../../src/collection.json');
+
+export const depsCallsReturnTypesFile = join(__dirname, './test-data/deps-calls-with-return-types.ts');
+export const depsCallsReturnTypesFileContents = () =>
+    readFileSync(depsCallsReturnTypesFile).toString('utf8');

--- a/tests/spec/spec-create.add-observable-and-promise-spy-return.spec.ts
+++ b/tests/spec/spec-create.add-observable-and-promise-spy-return.spec.ts
@@ -1,0 +1,29 @@
+import { Tree } from '@angular-devkit/schematics';
+import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
+import {
+    collectionPath,
+    depsCallsReturnTypesFile,
+    depsCallsReturnTypesFileContents,
+} from './common';
+
+describe('spec for a class with a method calling a dependency method', () => {
+    it('should add EMPTY for the dep method returning an observable', async () => {
+        // arrange
+        const tree = Tree.empty();
+        tree.create(depsCallsReturnTypesFile, depsCallsReturnTypesFileContents());
+        const runner = new SchematicTestRunner('schematics', collectionPath);
+
+        // act
+        const result = await runner
+            .runSchematicAsync('spec', { name: depsCallsReturnTypesFile, update: false }, tree)
+            .toPromise()
+            .catch(console.error);
+
+        // assert
+
+        const specFile = result!.readContent(depsCallsReturnTypesFile.replace('.ts', '.spec.ts'));
+        expect(specFile).toBeDefined();
+        expect(specFile).toMatch('service.observableReturning.and.returnValue(EMPTY)')
+        expect(specFile).toMatch('service.promiseReturning.and.returnValue(new Promise())');
+    });
+});

--- a/tests/spec/spec-create.add-observable-and-promise-spy-return.spec.ts
+++ b/tests/spec/spec-create.add-observable-and-promise-spy-return.spec.ts
@@ -16,8 +16,7 @@ describe('spec for a class with a method calling a dependency method', () => {
         // act
         const result = await runner
             .runSchematicAsync('spec', { name: depsCallsReturnTypesFile, update: false }, tree)
-            .toPromise()
-            .catch(console.error);
+            .toPromise();
 
         // assert
 

--- a/tests/spec/spec-create.spec.ts
+++ b/tests/spec/spec-create.spec.ts
@@ -18,7 +18,7 @@ describe('spec', () => {
 
     it('creates a file when name is passed in', async  () => {
         const runner = new SchematicTestRunner('schematics', collectionPath);
-        const result = await runner.runSchematicAsync('spec', { name: 'empty-class.ts' }, tree).toPromise();
+        const result = await runner.runSchematicAsync('spec', { name: 'empty-class.ts'}, tree).toPromise();
         expect(result.files.length).toBe(2); // the empty class + the new spec file
         expect(result.files[1]).toMatch('empty-class.spec.ts');
     });

--- a/tests/spec/test-data/deps-calls-with-return-types.dependency.ts
+++ b/tests/spec/test-data/deps-calls-with-return-types.dependency.ts
@@ -1,0 +1,17 @@
+/** starts on next line*/
+import { of } from 'rxjs';
+import { ClassDescription } from '../../../src/types'
+
+export class ServiceWithMethods {
+    constructor() {}
+
+    observableReturning() {
+        return of('emit-and-complete');
+    }
+    promiseReturning() {
+        return Promise.resolve('resolved')
+    }
+    justAMethod() {
+        return <ClassDescription>{constructorParams: [], name: 'a name', publicMethods: ['asdad'], type: 'class'}
+    }
+}

--- a/tests/spec/test-data/deps-calls-with-return-types.ts
+++ b/tests/spec/test-data/deps-calls-with-return-types.ts
@@ -1,0 +1,16 @@
+/** starts on next line*/
+import { switchMap } from 'rxjs/operators';
+import { ServiceWithMethods } from './deps-calls-with-return-types.dependency';
+
+
+export class ExampleComponent {
+    constructor(private readonly service:ServiceWithMethods) {}
+
+    async aMethod() {
+        const d = this.service.justAMethod();
+
+        return this.service.observableReturning().pipe(
+            switchMap(v => this.service.promiseReturning())
+        );
+    }
+}

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -22,5 +22,5 @@
     "outDir": "../dist-spec"
   },
   "include": ["src/**/*.ts", "tests/**/*.ts", "lib/**/*.ts"],
-  "exclude": ["src/files/**/*.*", "tests/spec/files/**/*.*", "example/**/*.*", "**/files/"]
+  "exclude": ["src/files/**/*.*", "tests/spec/files/**/*.*", "example/**/*.*", "**/files/", "test/spec/test-data/"]
 }


### PR DESCRIPTION
 - get the types and names of the methods used in the dependencies
 - for each of those
    - if they are Observable< or Subject< return an EMPTY from the spied method in the spec
    - if they are Promise< add a new Promise(res, rej) as a return for the spied method in the spec

# https://github.com/gparlakov/scuri/issues/148 #148