### PR TITLE
Feat/update with observable and promise stubs

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -14,5 +14,6 @@ module.exports = {
         '^src/(.*)$': '<rootDir>/src/$1'
     },
     transformIgnorePatterns: ['node_modules/(?!@ngrx)', 'node_modules/(?!(jest-test))'],
-    roots: ['tests', 'src']
+    roots: ['tests', 'src'],
+    testPathIgnorePatterns: ['<rootDir>/tests/spec/test-data']
 };

--- a/src/common/add-observable-promise-stubs.ts
+++ b/src/common/add-observable-promise-stubs.ts
@@ -1,0 +1,23 @@
+import { EOL } from 'os';
+import { ConstructorParam, DependencyMethodReturnTypes } from '../types';
+
+export function addDefaultObservableAndPromiseToSpy(p: ConstructorParam, deps?: DependencyMethodReturnTypes, joinWith?: string): string {
+    if(!deps?.has(p.type)) {
+        return ''
+    }
+    const joiner = typeof joinWith === 'string' ? joinWith : EOL;
+    const dep = deps.get(p.type);
+    const observables = Array.from(dep!.entries())
+        .filter(([_, value]) => value.match(/Observable<|Subject</))
+        .map(([key,]) => `${p.name}.${key}.and.returnValue(EMPTY)`)
+        .join(joiner)
+
+    const promises = Array.from(dep!.entries())
+        .map(([key, value]) => {
+            return [key, value];
+        })
+        .filter(([_, value]) => value.match(/Promise</))
+        .map(([key]) => `${p.name}.${key}.and.returnValue(new Promise(res => {}))`)
+        .join(joiner);
+    return `${typeof joinWith === 'string'? joinWith : ''}${observables}${joiner}${promises}`;
+}

--- a/src/common/add-observable-promise-stubs.ts
+++ b/src/common/add-observable-promise-stubs.ts
@@ -1,23 +1,39 @@
 import { EOL } from 'os';
 import { ConstructorParam, DependencyMethodReturnTypes } from '../types';
 
-export function addDefaultObservableAndPromiseToSpy(p: ConstructorParam, deps?: DependencyMethodReturnTypes, joinWith?: string): string {
+export function addDefaultObservableAndPromiseToSpyJoined(p: ConstructorParam, deps?: DependencyMethodReturnTypes, options?: DefaultMethodReturnsOptions): string {
     if(!deps?.has(p.type)) {
         return ''
     }
-    const joiner = typeof joinWith === 'string' ? joinWith : EOL;
+    const joiner = typeof options?.joiner === 'string' ? options?.joiner : EOL;
+    
+    return `${typeof joiner === 'string'? joiner : ''}${addDefaultObservableAndPromiseToSpy(p, deps, options).join(joiner)}`;
+}
+
+export function addDefaultObservableAndPromiseToSpy(p: ConstructorParam, deps?: DependencyMethodReturnTypes, options?: DefaultMethodReturnsOptions): string[] {
+    if(!deps?.has(p.type)) {
+        return []
+    }
+    const spyReturn = (v: string) => options?.spyReturnType === 'jest' ? `.mockReturnValue(${v})` : `.and.returnValue(${v})`;
     const dep = deps.get(p.type);
     const observables = Array.from(dep!.entries())
         .filter(([_, value]) => value.match(/Observable<|Subject</))
-        .map(([key,]) => `${p.name}.${key}.and.returnValue(EMPTY)`)
-        .join(joiner)
+        .map(([key,]) => `${p.name}.${key}${spyReturn('EMPTY')}`);
 
     const promises = Array.from(dep!.entries())
         .map(([key, value]) => {
             return [key, value];
         })
         .filter(([_, value]) => value.match(/Promise</))
-        .map(([key]) => `${p.name}.${key}.and.returnValue(new Promise(res => {}))`)
-        .join(joiner);
-    return `${typeof joinWith === 'string'? joinWith : ''}${observables}${joiner}${promises}`;
+        .map(([key]) => `${p.name}.${key}${spyReturn('new Promise(res => {})')}`);
+    return [...observables, ...promises];
+}
+
+interface DefaultMethodReturnsOptions {
+    joiner?: string;
+    spyReturnType?: 'jasmine' | 'jest';
+}
+
+export function listAllDefaultReturns(params: ConstructorParam[], deps?: DependencyMethodReturnTypes, options?: DefaultMethodReturnsOptions) {
+    return params.flatMap(p => addDefaultObservableAndPromiseToSpy(p, deps, options))
 }

--- a/src/spec/index.ts
+++ b/src/spec/index.ts
@@ -17,7 +17,7 @@ import { cosmiconfigSync } from 'cosmiconfig';
 import { EOL } from 'os';
 import { resolve } from 'path';
 import { Change, InsertChange, RemoveChange } from '../../lib/utility/change';
-import { addDefaultObservableAndPromiseToSpy } from '../common/add-observable-promise-stubs';
+import { addDefaultObservableAndPromiseToSpyJoined } from '../common/add-observable-promise-stubs';
 import { getSpecFilePathName } from '../common/get-spec-file-name';
 import { paths } from '../common/paths';
 import { describeSource } from '../common/read/read';
@@ -87,8 +87,7 @@ export function spec({ name, update, classTemplate, functionTemplate, config }: 
             e = e || {};
             logger.error(e.message || 'An error occurred');
             logger.debug(
-                `---Error--- ${EOL}${e.message || 'Empty error message'} ${
-                    e.stack || 'Empty stack.'
+                `---Error--- ${EOL}${e.message || 'Empty error message'} ${e.stack || 'Empty stack.'
                 }`
             );
         }
@@ -245,18 +244,18 @@ function createNewSpec(
                     .map((p) =>
                         p.type === 'string' || p.type === 'number'
                             ? `let ${p.name}:${p.type};`
-                            : `const ${p.name} = autoSpy(${p.type});${addDefaultObservableAndPromiseToSpy(p, depsCallsAndTypes, EOL)}`
+                            : `const ${p.name} = autoSpy(${p.type});${addDefaultObservableAndPromiseToSpyJoined(p, depsCallsAndTypes, { joiner: EOL, spyReturnType: 'jasmine' })}`
                     )
                     .join(EOL);
             }
             function toBuilderExports() {
                 return params.length > 0
                     ? params
-                          .map((p) => p.name)
-                          .join(',' + EOL)
-                          .concat(',')
+                        .map((p) => p.name)
+                        .join(',' + EOL)
+                        .concat(',')
                     : '';
-            }            
+            }
         } catch (e) {
             if (e != null && e.message === 'No classes found to be spec-ed!') {
                 const funktion = getFirstFunction(fileNameRaw, content);

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,13 +12,15 @@ export type DepType = string & {___type?: 'DepType'};
 export type MethodName = string & {___type?: 'MethodName'}; ;
 export type ReturnType = string & {___type?: 'ReturnType'};
 
+export type DependencyMethodReturnTypes = Map<DepType, Map<MethodName, ReturnType>>;
+
 export type ClassDescription = {
     type: 'class';
     name: string;
     constructorParams: ConstructorParam[];
     publicMethods: string[];
 
-    depsCallsAndTypes?: Map<DepType, Map<MethodName, ReturnType>>;
+    depsCallsAndTypes?: DependencyMethodReturnTypes;
 };
 
 export type ConstructorParam = {

--- a/tests/spec/common.ts
+++ b/tests/spec/common.ts
@@ -3,6 +3,9 @@ import { readFileSync } from 'fs';
 
 export const collectionPath = join(__dirname, '../../collection.json');
 
-export const depsCallsReturnTypesFile = join(__dirname, './test-data/deps-calls-with-return-types.ts');
-export const depsCallsReturnTypesFileContents = () =>
-    readFileSync(depsCallsReturnTypesFile).toString('utf8');
+
+export const getTestFile = (fileName: string) => join(__dirname, './test-data', fileName);
+export const getTestFileContents = (fullFilePath: string) => readFileSync(fullFilePath).toString('utf8');
+
+export const depsCallsReturnTypesFile = getTestFile('deps-calls-with-return-types.ts');
+export const depsCallsReturnTypesFileContents = () => getTestFileContents(depsCallsReturnTypesFile);

--- a/tests/spec/spec-update.add-observable-and-promise-spy-return.spec.ts
+++ b/tests/spec/spec-update.add-observable-and-promise-spy-return.spec.ts
@@ -1,0 +1,28 @@
+import { Tree } from '@angular-devkit/schematics';
+import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
+import {
+    collectionPath,
+    depsCallsReturnTypesFile,
+    depsCallsReturnTypesFileContents,
+} from './common';
+
+describe('spec for a class with a method calling a dependency method', () => {
+    it('should add EMPTY for the dep method returning an observable', async () => {
+        // arrange
+        const tree = Tree.empty();
+        tree.create(depsCallsReturnTypesFile, depsCallsReturnTypesFileContents());
+        const runner = new SchematicTestRunner('schematics', collectionPath);
+
+        // act
+        const result = await runner
+            .runSchematicAsync('spec', { name: depsCallsReturnTypesFile, update: false }, tree)
+            .toPromise();
+
+        // assert
+
+        const specFile = result!.readContent(depsCallsReturnTypesFile.replace('.ts', '.spec.ts'));
+        expect(specFile).toBeDefined();
+        expect(specFile).toMatch('service.observableReturning.and.returnValue(EMPTY)')
+        expect(specFile).toMatch('service.promiseReturning.and.returnValue(new Promise(res => {}))');
+    });
+});

--- a/tests/spec/spec-update.add-observable-and-promise-spy-return.spec.ts
+++ b/tests/spec/spec-update.add-observable-and-promise-spy-return.spec.ts
@@ -2,25 +2,48 @@ import { Tree } from '@angular-devkit/schematics';
 import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
 import {
     collectionPath,
-    depsCallsReturnTypesFile,
-    depsCallsReturnTypesFileContents,
+    getTestFile,
+    getTestFileContents
 } from './common';
 
 describe('spec for a class with a method calling a dependency method', () => {
     it('should add EMPTY for the dep method returning an observable', async () => {
         // arrange
+        const depsCallsReturnTypesFile = getTestFile('deps-calls-with-return-types.ts')
+        const specFileName = depsCallsReturnTypesFile.replace('.ts', '.spec.ts');
         const tree = Tree.empty();
-        tree.create(depsCallsReturnTypesFile, depsCallsReturnTypesFileContents());
+        tree.create(depsCallsReturnTypesFile, getTestFileContents(depsCallsReturnTypesFile));
+        tree.create(specFileName, getTestFileContents(specFileName));
         const runner = new SchematicTestRunner('schematics', collectionPath);
 
         // act
         const result = await runner
-            .runSchematicAsync('spec', { name: depsCallsReturnTypesFile, update: false }, tree)
+            .runSchematicAsync('spec', { name: depsCallsReturnTypesFile, update: true }, tree)
             .toPromise();
 
         // assert
-
         const specFile = result!.readContent(depsCallsReturnTypesFile.replace('.ts', '.spec.ts'));
+        expect(specFile).toBeDefined();
+        expect(specFile).toMatch('service.observableReturning.and.returnValue(EMPTY)')
+        expect(specFile).toMatch('service.promiseReturning.and.returnValue(new Promise(res => {}))');
+    });
+
+    it('should add EMPTY for the dep method returning an observable when dependency is already part of the spec', async () => {
+        // arrange
+        const tree = Tree.empty();
+        const fileName = getTestFile('deps-calls-with-return-types-dep-included.ts');
+        const specFileName = fileName.replace('.ts', '.spec.ts');
+        tree.create(fileName, getTestFileContents(fileName));
+        tree.create(specFileName, getTestFileContents(specFileName));
+        const runner = new SchematicTestRunner('schematics', collectionPath);
+
+        // act
+        const result = await runner
+            .runSchematicAsync('spec', { name: fileName, update: true }, tree)
+            .toPromise();
+
+        // assert
+        const specFile = result!.readContent(fileName.replace('.ts', '.spec.ts'));
         expect(specFile).toBeDefined();
         expect(specFile).toMatch('service.observableReturning.and.returnValue(EMPTY)')
         expect(specFile).toMatch('service.promiseReturning.and.returnValue(new Promise(res => {}))');

--- a/tests/spec/test-data/deps-calls-with-return-types-dep-included.spec.ts
+++ b/tests/spec/test-data/deps-calls-with-return-types-dep-included.spec.ts
@@ -1,0 +1,22 @@
+import { ServiceWithMethods } from './deps-calls-with-return-types.dependency';
+import { ExampleComponent } from './deps-calls-with-return-types';
+import { autoSpy } from 'autoSpy';
+
+describe('ExampleComponent', () => {
+
+  
+});
+
+function setup() {
+  const service = autoSpy(ServiceWithMethods);
+  const builder = {
+    default() {
+      return builder;
+    },
+    build() {
+      return new ExampleComponent(service);
+    }
+  };
+
+  return builder;
+}

--- a/tests/spec/test-data/deps-calls-with-return-types-dep-included.ts
+++ b/tests/spec/test-data/deps-calls-with-return-types-dep-included.ts
@@ -1,0 +1,15 @@
+/** starts on next line*/
+import { switchMap } from 'rxjs/operators';
+import { ServiceWithMethods } from './deps-calls-with-return-types.dependency';
+
+export class ExampleComponent {
+    constructor(private readonly service: ServiceWithMethods) { }
+
+    async aMethod() {
+        const d = this.service.justAMethod();
+
+        return this.service.observableReturning().pipe(
+            switchMap(v => this.service.promiseReturning())
+        );
+    }
+}

--- a/tests/spec/test-data/deps-calls-with-return-types.spec.ts
+++ b/tests/spec/test-data/deps-calls-with-return-types.spec.ts
@@ -1,0 +1,22 @@
+import { ServiceWithMethods } from './deps-calls-with-return-types.dependency';
+import { ExampleComponent } from './deps-calls-with-return-types';
+import { autoSpy } from 'autoSpy';
+
+describe('ExampleComponent', () => {
+
+  
+});
+
+function setup() {
+
+  const builder = {
+    default() {
+      return builder;
+    },
+    build() {
+      return new ExampleComponent();
+    }
+  };
+
+  return builder;
+}

--- a/tests/spec/test-data/deps-calls-with-return-types.ts
+++ b/tests/spec/test-data/deps-calls-with-return-types.ts
@@ -2,7 +2,6 @@
 import { switchMap } from 'rxjs/operators';
 import { ServiceWithMethods } from './deps-calls-with-return-types.dependency';
 
-
 export class ExampleComponent {
     constructor(private readonly service:ServiceWithMethods) {}
 

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -22,5 +22,5 @@
     "outDir": "../dist-spec"
   },
   "include": ["src/**/*.ts", "tests/**/*.ts", "lib/**/*.ts"],
-  "exclude": ["src/files/**/*.*", "tests/spec/files/**/*.*", "example/**/*.*", "**/files/", "test/spec/test-data/"]
+  "exclude": ["src/files/**/*.*", "tests/spec/files/**/*.*", "example/**/*.*", "**/files/", "test/spec/test-data/*.*"]
 }


### PR DESCRIPTION
- when dependency methods return Promise or Observable and scuri is updating the specs it will include defaults (Promise and EMPTY) 
- both of these allow for continuing the chaining without breaking for `.pipe is not part of undefined` and `.then is not part of undefined` type errors