### PR TITLE
feat: custom no functions

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - fixed error when trying to overwrite existing specs
+- fixed behavior when custom template has no custom functions - just use standard update when `scuri:spec --update` or throw if user specified `scuri:update-custom`
 
 ## 1.3.0 - 2022-08-30
 

--- a/src/common/scuri-custom-update-template.ts
+++ b/src/common/scuri-custom-update-template.ts
@@ -3,17 +3,19 @@ export interface Template {
     template: string;
 }
 
+const scuri = 'scuri:'
+const templateMark = 'template:';
+export const scuriTemplateMark = `${scuri}${templateMark}`
+
 export function updateCustomTemplateCut(classTemplate: string): [rest: string, templates: Template[]] {
-    const scuri = 'scuri:'
-    const templateMark = 'template:';
-    if (typeof classTemplate !== 'string' || !classTemplate.includes(`${scuri}${templateMark}`)) {
+    if (typeof classTemplate !== 'string' || !classTemplate.includes(`${scuriTemplateMark}`)) {
         return [classTemplate, []];
     }
 
     const splitBy = `/**${scuri}`;
     const fileSplit = classTemplate
-        // remove whitespaces /**  scuri:tempalte -> /**scuri:template
-        .replace(/\s*scuri:template:/g, `${scuri}${templateMark}`)
+        // remove white-spaces '/**  scuri:template ' -> '/**scuri:template:'
+        .replace(/\s*scuri:template:/g, `${scuriTemplateMark}`)
         .split(splitBy, 200);
 
     const contents = fileSplit.filter((f) => !f.includes(templateMark)).join('');

--- a/src/spec/index.ts
+++ b/src/spec/index.ts
@@ -22,7 +22,7 @@ import { addDefaultObservableAndPromiseToSpyJoined } from '../common/add-observa
 import { getSpecFilePathName } from '../common/get-spec-file-name';
 import { paths } from '../common/paths';
 import { describeSource } from '../common/read/read';
-import { updateCustomTemplateCut } from '../common/scuri-custom-update-template';
+import { scuriTemplateMark, updateCustomTemplateCut } from '../common/scuri-custom-update-template';
 import {
     ClassDescription,
     FunctionDescription,
@@ -75,11 +75,14 @@ export function spec({ name, update, classTemplate, functionTemplate, config }: 
                 )}] but that file seems to be missing.`
             );
         }
+
         try {
             if (update) {
-                if (classTemplate) {
+                if (classTemplate && tree.exists(classTemplate) && tree.read(classTemplate)?.toString()?.includes(scuriTemplateMark)) {
+                    logger.debug(`Switching to update custom ${classTemplate}`)
                     return schematic('update-custom', { name, classTemplate });
                 }
+                logger.debug(`Updating name ${name}`);
                 return updateExistingSpec(name, tree, logger);
             } else {
                 return createNewSpec(name, tree, logger, { classTemplate, functionTemplate });

--- a/src/spec/update/update.ts
+++ b/src/spec/update/update.ts
@@ -362,7 +362,7 @@ function addProvidersForTestBed(
                 new InsertChange(
                     path,
                     openingBracketPosition,
-                    `${firstChildIndentation}const ${a} = ${setupFunctionName}().default();`
+                    `${EOL}${firstChildIndentation}const ${a} = ${setupFunctionName}().default();`
                 )
             ]
             : [];

--- a/tests/spec/spec-update.spec-created-with-custom-template-without-custom-functions.spec.ts
+++ b/tests/spec/spec-update.spec-created-with-custom-template-without-custom-functions.spec.ts
@@ -1,0 +1,185 @@
+import { Tree } from '@angular-devkit/schematics';
+import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
+import { Subject } from 'rxjs';
+import { Options } from '../../src/update-custom/index';
+import { collectionPath } from '../spec/common';
+describe('update', () => {
+    let tree: Tree;
+    const name = 'example.ts';
+    const specFileName = 'example.spec.ts';
+    const classTemplate = '__specFileName__.template';
+    let stop$: Subject<void>;
+
+    beforeEach(() => {
+        tree = Tree.empty();
+
+        tree.create(name, fileContent());
+        tree.create(specFileName, specFileContent());
+        tree.create(classTemplate, template());
+
+        stop$ = new Subject<void>();
+    });
+
+    afterEach(() => {
+        stop$.next();
+    });
+
+    it('should run standard update', async () => {
+        const runner = new SchematicTestRunner('schematics', collectionPath);
+
+        await runner
+            .runSchematicAsync(
+                'spec',
+                <Options>{ name, classTemplate, specFileContents: specFileContent(), update: true },
+                tree
+            )
+            .toPromise();
+
+        expect(tree.read(specFileName)?.toString()).toMatchInlineSnapshot(`
+            "import { MyDirective } from './directive';
+            import { autoSpy, spyInject } from 'jasmine-auto-spies';
+            import { Service } from './service';
+            import { Router } from '@the/router';
+            import { Just } from 'maybe';
+
+            describe('ExampleComponent', () => {
+
+                beforeEach(async(() => {
+                    const a = setup().default();
+                    TestBed.configureTestingModule({
+                        providers: [
+                            MyDirective,
+                            { provide: Service, useClass: autoSpy(Service, 'Service') },
+                        ]
+                    }).configureTestingModule({ providers: [{ provide: Router, useValue: a.router },
+                        { provide: Just, useValue: a.just }] });
+
+                    directive = TestBed.inject(MyDirective);
+                }));
+
+                it('when myMethod is called it should', () => {
+                    // arrange
+                    // act
+                    e.myMethod();
+                    // assert
+                    // expect(e).toEqual
+                });
+                it('when yourMethod is called it should', () => {
+                    // arrange
+                    const { build } = setup().default();
+                    const e = build();
+                    // act
+                    e.yourMethod();
+                    // assert
+                    // expect(e).toEqual
+                });
+                it('when theirMethod is called it should', () => {
+                    // arrange
+                    const { build } = setup().default();
+                    const e = build();
+                    // act
+                    e.theirMethod();
+                    // assert
+                    // expect(e).toEqual
+                });
+            });
+
+            function setup() {
+                const service = autoSpy(Service);
+                const router = autoSpy(Router);
+                const just = autoSpy(Just);
+                const builder = {
+                    service,
+                    router,
+                    just,
+                    default() {
+                        return builder;
+                    },
+                    build() {
+                        return new ExampleComponent(service, router, just);
+                    }
+                }
+                return builder;
+            }"
+        `);
+    });
+});
+
+function fileContent(): string {
+    return `import { Router } from "@the/router";
+import { Just } from "maybe";
+import { Service } from "./service";
+export class ExampleComponent {
+    constructor(service: Service, router: Router, just: Just) {}
+
+    myMethod() {}
+
+    yourMethod() {}
+
+    theirMethod() {}
+}
+`;
+}
+
+function specFileContent(): string {
+    return `import { MyDirective } from './directive';
+import { autoSpy, spyInject } from 'jasmine-auto-spies';
+
+describe('ExampleComponent', () => {
+
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+            providers: [
+                MyDirective,
+                { provide: Service, useClass: autoSpy(Service, 'Service') },
+            ]
+        });
+
+        directive = TestBed.inject(MyDirective);
+    }));
+
+    it('when myMethod is called it should', () => {
+        // arrange
+        // act
+        e.myMethod();
+        // assert
+        // expect(e).toEqual
+    });
+});
+`;
+}
+
+function template() {
+    return `<% params.forEach(p => { if(p.importPath) {%>import { <%= p.type %> } from '<%= p.importPath %>';
+<% }}) %>import { <%= className %> } from './<%= normalizedName %>';
+import { autoSpy, spyInject } from 'jasmine-auto-spies';
+
+describe('<%= className %>', () => {
+  <%params.forEach(p => {%> let <%= p.type %>Spy: <%= p.type %>;
+      <% }) %>
+  beforeEach(
+  waitForAsync(() => {
+      TestBed.configureTestingModule({
+      providers: [
+              MyDirective,
+          <%params.forEach(p => {%> { provide: <%= p.type %>, useClass: autoSpy(<%= p.type %>, '<%= p.type %>') },
+          <% }) %>      ]
+      });
+
+      directive = TestBed.inject(MyDirective);
+      <%params.forEach(p => {%> <%= p.type %>Spy = spyInject<<%= p.type %>>(TestBed.inject(<%= p.type %>));
+      <% }) %>
+  })
+  );
+
+  <% publicMethods.forEach(meth=> {if(meth != '') { %>it('when <%= meth %> is called it should', () => {
+  // arrange
+  // act
+  <%= shorthand %>.<%= meth %>();
+  // assert
+  // expect(<%= shorthand %>).toEqual
+  });
+  <% }}) %>
+});
+`;
+}

--- a/tests/update-custom/update-custom-green-path.debug-logs.spec.ts
+++ b/tests/update-custom/update-custom-green-path.debug-logs.spec.ts
@@ -21,7 +21,9 @@ describe('update-custom', () => {
         stop$ = new Subject<void>();
     });
 
-    afterEach(() => { stop$.next() });
+    afterEach(() => {
+        stop$.next();
+    });
 
     it('should debug-output the skipped methods and the template results prior to dedupe', async () => {
         const runner = new SchematicTestRunner('schematics', collectionPath);
@@ -38,6 +40,7 @@ describe('update-custom', () => {
         // skipping methods
         expect(logs).toMatchInlineSnapshot(`
             Array [
+              "Cut the template to parts [{\\"mark\\":\\"lets\\",\\"template\\":\\"<%params.forEach(p => {%>let <%= camelize(p.type) %>Spy: <%= p.type %>;\\\\n<% }) %>\\"},{\\"mark\\":\\"injectables\\",\\"template\\":\\"<%params.forEach(p => {%>{ provide: <%= p.type %>, useClass: autoSpy(<%= p.type %>, '<%= p.type %>') },\\\\n<% }) %>\\"},{\\"mark\\":\\"get-instances\\",\\"template\\":\\"<%params.forEach(p => {%><%= camelize(p.type) %>Spy = spyInject<<%= p.type %>>(TestBed.inject(<%= p.type %>));\\\\n<% }) %>\\"},{\\"mark\\":\\"methods-skipDeDupe\\",\\"template\\":\\"<% publicMethods.forEach(meth=> {if(meth != '') { %>it('when <%= meth %> is called it should', () => {\\\\n    // arrange\\\\n    // act\\\\n    <%= shorthand %>.<%= meth %>();\\\\n    // assert\\\\n    // expect(<%= shorthand %>).toEqual\\\\n});\\\\n<% }}) %>\\"}]",
               "Skipping methods: [myMethod] as they seem to be already in the spec.",
               "Template result before de-duplication: [let serviceSpy: Service;
             let routerSpy: Router;
@@ -69,7 +72,6 @@ describe('update-custom', () => {
                 // expect(e).toEqual
             });
             ]",
-              "Mark // scuri:methods (original methods-skipDeDupe) found at position(741)",
             ]
         `);
     });
@@ -100,7 +102,7 @@ describe('update-custom', () => {
         );
         tree.commitUpdate(r);
         const runner = new SchematicTestRunner('schematics', collectionPath);
-        const logs = subscribe(listenLogger(runner.logger, { level: 'error' }), stop$); 
+        const logs = subscribe(listenLogger(runner.logger, { level: 'error' }), stop$);
 
         await runner
             .runSchematicAsync(

--- a/tests/update-custom/update-custom-mark-case-insensitive-and-methods-inside-describe.spec.ts
+++ b/tests/update-custom/update-custom-mark-case-insensitive-and-methods-inside-describe.spec.ts
@@ -31,8 +31,8 @@ describe('update-custom', () => {
             describe('ToUpdateComponent', () => {
 
                 let serviceSpy: Service;
-                 let routerSpy: Router;
-                 let justSpy: Just;
+                let routerSpy: Router;
+                let justSpy: Just;
                 // scuri:lets
 
                 beforeEach(
@@ -42,8 +42,8 @@ describe('update-custom', () => {
                                 MyDirective,
 
                                 { provide: Service, useClass: autoSpy(Service, 'Service') },
-                                 { provide: Router, useClass: autoSpy(Router, 'Router') },
-                                 { provide: Just, useClass: autoSpy(Just, 'Just') },
+                                { provide: Router, useClass: autoSpy(Router, 'Router') },
+                                { provide: Just, useClass: autoSpy(Just, 'Just') },
                                 // scuri:injectables
                             ]
                         });
@@ -51,8 +51,8 @@ describe('update-custom', () => {
                         directive = TestBed.inject(MyDirective);
 
                         serviceSpy = spyInject<Service>(TestBed.inject(Service));
-                         routerSpy = spyInject<Router>(TestBed.inject(Router));
-                         justSpy = spyInject<Just>(TestBed.inject(Just));
+                        routerSpy = spyInject<Router>(TestBed.inject(Router));
+                        justSpy = spyInject<Just>(TestBed.inject(Just));
                         // scuri:get-instances
 
                     })
@@ -68,7 +68,13 @@ describe('update-custom', () => {
 
 
                 it('when mySecondMethod is called it should', () => {
+                    // arrange
+                    // act
                     t.mySecondMethod();
+                    // assert
+                    // expect(t).toEqual
+                });
+
             // scuri:Methods
 
             });
@@ -176,18 +182,18 @@ describe('<%= className %>', () => {
 });
 
 /** scuri:template:lets:<%params.forEach(p => {%>let <%= camelize(p.type) %>Spy: <%= p.type %>;
- <% }) %>*/
+<% }) %>*/
     /** scuri:template:injectables:<%params.forEach(p => {%>{ provide: <%= p.type %>, useClass: autoSpy(<%= p.type %>, '<%= p.type %>') },
- <% }) %>*/
+<% }) %>*/
     /** scuri:template:get-instances:<%params.forEach(p => {%><%= camelize(p.type) %>Spy = spyInject<<%= p.type %>>(TestBed.inject(<%= p.type %>));
- <% }) %>*/
+<% }) %>*/
     /** scuri:template:methods-skipDedupe:<% publicMethods.forEach(meth=> {if(meth != '') { %>it('when <%= meth %> is called it should', () => {
-     // arrange
+        // arrange
         // act
         <%= shorthand %>.<%= meth %>();
         // assert
         // expect(<%= shorthand %>).toEqual
     });
-    <% }}) %>*/
+<% }}) %>*/
 `;
 }

--- a/tests/update-custom/update-custom-template-without-functions.spec.ts
+++ b/tests/update-custom/update-custom-template-without-functions.spec.ts
@@ -1,0 +1,115 @@
+import { Tree } from '@angular-devkit/schematics';
+import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
+import { Options } from '../../src/update-custom/index';
+import { collectionPath } from '../spec/common';
+
+describe('update-custom without scuri:template: ', () => {
+    let tree: Tree;
+    const name = 'to-update.component.ts';
+    const specFileName = 'to-update.component.custom.spec.ts';
+    const classTemplate = '__normalizedName__.custom.spec.ts.template';
+
+    beforeEach(() => {
+        tree = Tree.empty();
+
+        tree.create(name, fileContent());
+        tree.create(specFileName, specFileContent());
+        tree.create(classTemplate, template());
+    });
+
+    it('should throw error', async () => {
+        const runner = new SchematicTestRunner('schematics', collectionPath);
+        await runner
+            .runSchematicAsync('update-custom', <Options>{ name, classTemplate }, tree)
+            .toPromise()
+            .catch(e => {
+                expect(e).toEqual(
+                    new Error('The custom template seems to be missing the scuri:template: mark. Perhaps you need the standard update?')
+                );
+            });
+        });
+    });
+
+    function fileContent(): string {
+        return `import { Router } from '@the/router';
+import { Just } from 'maybe';
+import { Service } from './service';
+export class ToUpdateComponent {
+  constructor(service: Service, router: Router, just: Just) {}
+
+  myMethod() {}
+
+  mySecondMethod() {}
+}
+
+`;
+    }
+
+    function specFileContent(): string {
+        return `import { ToUpdateComponent } from './to-update.component';
+import { autoSpy, spyInject } from 'jasmine-auto-spies';
+
+describe('ToUpdateComponent', () => {
+
+    beforeEach(
+        waitForAsync(() => {
+            TestBed.configureTestingModule({
+                providers: [
+                    MyDirective,
+                ]
+            });
+
+            directive = TestBed.inject(MyDirective);
+        })
+    );
+
+    it('when myMethod is called it should', () => {
+        // arrange
+        // act
+        t.myMethod();
+        // assert
+        // expect(t).toEqual
+    });
+
+});
+
+`;
+    }
+
+    function template() {
+        return `<% params.forEach(p => { if(p.importPath) {%>import { <%= p.type %> } from '<%= p.importPath %>';
+<% }}) %>import { <%= className %> } from './<%= normalizedName %>';
+import { autoSpy, spyInject } from 'jasmine-auto-spies';
+
+describe('<%= className %>', () => {
+  <%params.forEach(p => {%> let <%= p.type %>Spy: <%= p.type %>;
+      <% }) %>
+
+  beforeEach(
+  waitForAsync(() => {
+      TestBed.configureTestingModule({
+      providers: [
+              MyDirective,
+          <%params.forEach(p => {%> { provide: <%= p.type %>, useClass: autoSpy(<%= p.type %>, '<%= p.type %>') },
+          <% }) %>
+      ]
+      });
+
+      directive = TestBed.inject(MyDirective);
+      <%params.forEach(p => {%> <%= p.type %>Spy = spyInject<<%= p.type %>>(TestBed.inject(<%= p.type %>));
+      <% }) %>
+
+  })
+  );
+
+  <% publicMethods.forEach(meth=> {if(meth != '') { %>it('when <%= meth %> is called it should', () => {
+  // arrange
+  // act
+  <%= shorthand %>.<%= meth %>();
+  // assert
+  // expect(<%= shorthand %>).toEqual
+  });
+  <% }}) %>
+});
+`;
+    }


### PR DESCRIPTION
- when a custom template is used but there are no scuri:template: ... functions
   - just use the standard update
   - or throw if user specified `update-custom`
- fix skipDeDupe to allow case insensitive match