### PR TITLE
feat: autodetect jest or jasmine

### DIFF
--- a/live-test.sh
+++ b/live-test.sh
@@ -28,7 +28,7 @@ if test -z "${DEBUG_LIVE_TEST}";  then
   ENTRYPOINT=$APP_DIR/$EXAMPLE_FOLDER/run-plus.sh
 else
   FLAGS='-it'
-  ENTRYPOINT=/bin/sh
+  ENTRYPOINT=/bin/bash
 fi
 
 docker run $FLAGS -v $(pwd)/example:$APP_DIR/example --entrypoint $ENTRYPOINT --net=host -e npm_config_registry=http://localhost:4873/ gparlakov/scuri:angular-14-app-v2

--- a/src/common/detect-testing-framework.ts
+++ b/src/common/detect-testing-framework.ts
@@ -1,0 +1,87 @@
+import { Tree } from '@angular-devkit/schematics';
+import { getLogger } from './logger';
+
+export type Supported = 'jest' | 'jasmine';
+const supported: Supported[] = ['jest', 'jasmine'];
+
+/**
+ * Take the framework from the 1. cli params or 2. config or 3. best effort autodetect
+ * @param cliParam command line interface param if any
+ * @param configParam configured param if any
+ * @param t Tree
+ * @param fallback - if all else fails use this
+ * @returns 'jest' | 'jasmine'
+ */
+export function detectTestingFramework(
+    cliParam: string | undefined,
+    configParam: string | undefined,
+    t: Tree,
+    fallback: Supported
+): 'jest' | 'jasmine' {
+    const logger = getLogger(detectTestingFramework.name);
+
+    logger.log('debug', 'entering');
+    if (typeof cliParam === 'string' && supported.includes(cliParam as Supported)) {
+        logger.debug(`Detected supported cli param ${cliParam}`);
+        return cliParam as Supported;
+    }
+    if (typeof cliParam === 'string') {
+        logger.warn(
+            `Detected un-supported cli param ${cliParam}. please use ${supported.join(' or ')}`
+        );
+    }
+    if (typeof configParam === 'string' && supported.includes(configParam as Supported)) {
+        logger.debug(`Detected supported config param ${cliParam}`);
+        return configParam as Supported;
+    }
+    if (typeof configParam === 'string') {
+        logger.warn(
+            `Detected un-supported config param ${configParam}. please use ${supported.join(
+                ' or '
+            )}`
+        );
+    }
+
+    const found: {
+        jest: string[];
+        jasmine: string[];
+    } = { jest: [], jasmine: [] };
+    t.visit((f, e) => {
+        if(f.includes('node_modules')) {
+            // skip node modules
+            return;
+        }
+
+        if (f.includes('jest.config')) {
+            found.jest.push(f);
+            logger.debug(`Detected jest by way of ${f}`);
+        } else if (f.includes('karma.conf')) {
+            found.jasmine.push(f);
+            logger.debug(`Detected jasmine by way of: ${f}`);
+        } else if (f.includes('package.json')) {
+            const content = e?.content.toString();
+            if (typeof content === 'string') {
+                if (content.includes('"jasmine-core"')) {
+                    found.jasmine.push(f);
+                    logger.debug(`Detected jasmine by way of ${f}`);
+                }
+                if (content.includes('"jest"')) {
+                    found.jest.push(f);
+                    logger.debug(`Detected jest by way of ${f}`);
+                }
+            }
+        }
+    });
+
+    if (found.jasmine.length > found.jest.length) {
+        logger.debug(`Detected jasmine by way of ${found.jasmine.join()}`);
+        return 'jasmine';
+    } else if (found.jest.length > found.jasmine.length) {
+        logger.debug(`Detected jest by way of ${found.jest.join()}`);
+        return 'jest';
+    } else {
+        // jest == jasmine
+        return fallback;
+        // todo - read through the files again and get the .mockReturnValue  and '.and.' numbers and .returnValue counts to make sure which type of runner is being used
+    }
+}

--- a/src/common/spec-file-name.ts
+++ b/src/common/spec-file-name.ts
@@ -1,3 +1,0 @@
-export function getSpecFileName(f: string): string {
-    return typeof f === 'string' ? f.replace('.ts', '.spec.ts') : f;
-}

--- a/src/spec/schema.json
+++ b/src/spec/schema.json
@@ -34,8 +34,7 @@
     "framework": {
       "type": "string",
       "alias": "f",
-      "description": "Only needed for Update. Can be set in Config too. Testing framework (jasmine or jest), default is jasmine",
-      "default": "jasmine"
+      "description": "Testing framework jasmine or jest. Only needed for Update. Can be set in Config too."
     }
   },
   "required": []

--- a/tests/spec/all.detect-testing-framework.spec.ts
+++ b/tests/spec/all.detect-testing-framework.spec.ts
@@ -1,0 +1,148 @@
+import { LogEntry } from '@angular-devkit/core/src/logger';
+import { Tree } from '@angular-devkit/schematics';
+import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
+import { filter } from 'rxjs/operators';
+import { collectionPath, getTestFile, getTestFileContents } from './common';
+import { getSpecFilePathName } from '../../src/common/get-spec-file-name';
+
+describe('Framework test runner config', () => {
+    it('should detect jasmine when karma.conf.js present', async () => {
+        // arrange
+        const { run, testFileName } = setup().default().add('karma.conf.js', '');
+        // act
+        const result = await run();
+        // assert
+        const contents = result.readContent(testFileName);
+        expect(contents).toMatch('service.observableReturning.and.returnValue(EMPTY);');
+        expect(contents).toMatch('service.observableReturning.and.returnValue(o);');
+    });
+
+    it('should detect jasmine when jasmine-core in package.json', async () => {
+        // arrange
+        const { run, testFileName } = setup()
+            .default()
+            .add('package.json', '{"deps": {"jasmine-core":"13.non-existent-version"}}');
+        // act
+        const result = await run();
+        // assert
+        const contents = result.readContent(testFileName);
+        expect(contents).toMatch('service.observableReturning.and.returnValue(EMPTY);');
+        expect(contents).toMatch('service.observableReturning.and.returnValue(o);');
+    });
+
+    it('should detect jasmine when karma.conf even if multiple package.json-s in node_modules have jest in them', async () => {
+        // arrange
+        const { run, testFileName } = setup()
+            .default()
+            .add('karma.conf.js', '')
+            .add('node_modules/package1/package.json', '{"deps": {"jest":"13.non-existent-version"}}')
+            .add('node_modules/package2/package.json', '{"deps": {"jest":"13.non-existent-version"}}')
+            .add('node_modules/package3/package.json', '{"deps": {"jest":"13.non-existent-version"}}')
+            ;
+        // act
+        const result = await run();
+        // assert
+        const contents = result.readContent(testFileName);
+        expect(contents).toMatch('service.observableReturning.and.returnValue(EMPTY);');
+        expect(contents).toMatch('service.observableReturning.and.returnValue(o);');
+    });
+
+
+    it('should use jasmine whn passed on the cli even if jest.config present', async () => {
+        // arrange
+        const { run, testFileName } = setup().default().add('jest.config.js', '');
+        // act
+        const result = await run({ framework: 'jasmine' });
+        // assert
+        const contents = result.readContent(testFileName);
+        expect(contents).toMatch('service.observableReturning.and.returnValue(EMPTY);');
+        expect(contents).toMatch('service.observableReturning.and.returnValue(o);');
+    });
+
+    it('should detect jest when jest.config present', async () => {
+        // arrange
+        const { run, testFileName } = setup()
+            .default()
+            .add('jest.config.mjs', '')
+            .log({ filter: 'determine----' });
+        // act
+        const result = await run();
+        // assert
+        const contents = result.readContent(testFileName);
+        expect(contents).toMatch('service.observableReturning.mockReturnValue(EMPTY);');
+        expect(contents).toMatch('service.observableReturning.mockReturnValue(o);');
+    });
+
+    it('should detect jest when jest in package.json', async () => {
+        // arrange
+        const { run, testFileName } = setup()
+            .default()
+            .add('package.json', '{"deps": {"jest":"13.non-existent-version"}}');
+        // act
+        const result = await run();
+        // assert
+        const contents = result.readContent(testFileName);
+        expect(contents).toMatch('service.observableReturning.mockReturnValue(EMPTY);');
+        expect(contents).toMatch('service.observableReturning.mockReturnValue(o);');
+    });
+
+    it('should use jest when passed in the cli args even if karma.conf present', async () => {
+        // arrange
+        const { run, testFileName } = setup()
+            .default()
+            .add('karma.conf', '{"deps": {"jest":"13.non-existent-version"}}');
+        // act
+        const result = await run({ framework: 'jest' });
+        // assert
+        const contents = result.readContent(testFileName);
+        expect(contents).toMatch('service.observableReturning.mockReturnValue(EMPTY);');
+        expect(contents).toMatch('service.observableReturning.mockReturnValue(o);');
+    });
+});
+
+function setup() {
+    const tree = Tree.empty();
+    const testFilesFolder = 'all.detect-testing-framework';
+    const defaultFileName = getTestFile(`${testFilesFolder}/component.ts`);
+    const runner = new SchematicTestRunner('schematics', collectionPath);
+    const builder = {
+        testFilesFolder,
+        defaultFileName,
+        testFileName: getSpecFilePathName(defaultFileName),
+        tree,
+        runner,
+        log(o?: { map?: (l: LogEntry) => unknown; filter?: string | ((l: LogEntry) => boolean) }) {
+            const mapFn = typeof o?.map === 'function' ? o.map : (m: LogEntry) => m;
+            const filterFn =
+                typeof o?.filter === 'function'
+                    ? o.filter
+                    : typeof o?.filter === 'string'
+                    ? (m: LogEntry) =>
+                          m.name.includes(o.filter as string) ||
+                          m.message.includes(o.filter as string)
+                    : () => true;
+
+            const c = console; // hide from tslint
+            runner.logger.pipe(filter((f) => filterFn(f))).subscribe((l) => c.log(mapFn(l)));
+
+            return builder;
+        },
+        add(name: string, contents: string) {
+            tree.create(name, contents);
+            return builder;
+        },
+        default() {
+            return builder.add(defaultFileName, getTestFileContents(defaultFileName));
+        },
+        build() {
+            return tree;
+        },
+        async run(o?: { framework?: string }) {
+            return runner
+                .runSchematicAsync('spec', { ...o, name: defaultFileName }, tree)
+                .toPromise();
+        },
+    };
+
+    return builder;
+}

--- a/tests/spec/test-data/all.detect-testing-framework/component.ts
+++ b/tests/spec/test-data/all.detect-testing-framework/component.ts
@@ -1,0 +1,9 @@
+import { ServiceWithMethods } from './dependency';
+
+export class ExampleComponentForDetectingFrameworkTestRunner {
+    constructor(private readonly service: ServiceWithMethods) {}
+
+    async aMethod() {
+        this.service.observableReturning().subscribe();
+    }
+}

--- a/tests/spec/test-data/all.detect-testing-framework/dependency.ts
+++ b/tests/spec/test-data/all.detect-testing-framework/dependency.ts
@@ -1,0 +1,7 @@
+import { Observable } from 'rxjs';
+
+export class ServiceWithMethods {
+    observableReturning(a?: string | undefined): Observable<string | number> {
+        return of(a ? a : 1);
+    }
+}


### PR DESCRIPTION
- jasmine is no longer schema default but fallback default
- spec-file-name duplicated `getSpecFilePathName` and very superficial
- framework was not getting passed in for creates