### PR TITLE
fix: don't re-add properties to auto-spy

### DIFF
--- a/src/spec/update/update.ts
+++ b/src/spec/update/update.ts
@@ -1,4 +1,3 @@
-import { classify } from '@angular-devkit/core/src/utils/strings';
 import { EOL } from 'os';
 import * as ts from 'typescript';
 import { findNodes, insertImport, isImported } from '../../../lib/utility/ast-utils';
@@ -312,7 +311,7 @@ function addDepPropsMocks({
                         deps,
                         /*skipWhen*/ depOrObj => depOrObj === 'checkShouldSkipObjectWrapper'
                             ? somePropsAdded
-                            : text.includes(`${p.name}${classify(depOrObj.name)}`)
+                            : text.includes(depOrObj.name)
                     )
                 )
             ];

--- a/tests/spec/spec-update.add-observable-and-promise-spy-return.spec.ts
+++ b/tests/spec/spec-update.add-observable-and-promise-spy-return.spec.ts
@@ -504,7 +504,7 @@ describe('spec for a class with a method calling a dependency method', () => {
         const specFile = result!.readContent(fileName.replace('.ts', '.spec.ts'));
         expect(specFile).toBeDefined();
         expect(specFile).toMatch(
-            'const service = autoSpy(ServiceWithMethods, {observable$: serviceObservable$, property$: serviceProperty$, promiseProp: servicePromiseProp, subject$: serviceSubject$});'
+            'const service = autoSpy(ServiceWithMethods, {observable$: someOther$, property$: serviceProperty$, promiseProp: servicePromiseProp, subject$: serviceSubject$});'
         );
     });
 
@@ -525,7 +525,7 @@ describe('spec for a class with a method calling a dependency method', () => {
         // assert
         const specFile = result!.readContent(fileName.replace('.ts', '.spec.ts'));
         expect(specFile).toBeDefined();
-        expect(specFile).toMatch('const serviceObservable$ = new BehaviorSubject(null);');
+        expect(specFile).toMatch('const someOther$ = new BehaviorSubject(null);');
         // don't add the same property mock 👇 as it already exists 👆
         expect(specFile).not.toMatch(
             'const serviceObservable$ = new ReplaySubject<ClassDescription[]>(1);'

--- a/tests/spec/test-data/update.add-methods.add-props-no-duplication/component.spec.ts
+++ b/tests/spec/test-data/update.add-methods.add-props-no-duplication/component.spec.ts
@@ -11,8 +11,8 @@ describe('ExampleComponent', () => {
 
 function setup() {
 
-  const serviceObservable$ = new BehaviorSubject(null);
-  const service = autoSpy(ServiceWithMethods, {observable$: serviceObservable$});
+  const someOther$ = new BehaviorSubject(null);
+  const service = autoSpy(ServiceWithMethods, {observable$: someOther$});
   service.promiseReturning.and.returnValue(Promise.resolve('some other thing'));
 
   const builder = {


### PR DESCRIPTION
- even if they are named different manner