### PR TITLE
fix: optimise detect testing framework

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -27,6 +27,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fixed error when trying to overwrite existing specs and using `--force` flag
 - fixed behavior when custom template has no custom functions - just use standard update when `scuri:spec --update` or throw if user specified `scuri:update-custom`
 
+## 1.3.2 - 2023-05-14
+
+### Fixed
+
+- only detect jest/jasmine via the root folder (don't use tree.visit as that reads ALL files and takes a lot of time)
+
+
 ## 1.3.1 - 2023-03-11
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scuri",
-  "version": "1.4.0-rc.5",
+  "version": "1.3.2",
   "description": "A spec generator schematic - Spec Create Update Read (class - component, service, directive and dependencies) Incorporate (them in the result)",
   "scripts": {
     "s": "schematics",

--- a/src/common/detect-testing-framework.ts
+++ b/src/common/detect-testing-framework.ts
@@ -46,20 +46,23 @@ export function detectTestingFramework(
         jest: string[];
         jasmine: string[];
     } = { jest: [], jasmine: [] };
-    t.visit((f, e) => {
+
+    const root = t.getDir('.');
+
+    root.subfiles.forEach(f => {
         if(f.includes('node_modules')) {
             // skip node modules
             return;
         }
 
-        if (f.includes('jest.config')) {
+        if (f.includes('jest')) {
             found.jest.push(f);
             logger.debug(`Detected jest by way of ${f}`);
-        } else if (f.includes('karma.conf')) {
+        } else if (f.includes('karma')) {
             found.jasmine.push(f);
             logger.debug(`Detected jasmine by way of: ${f}`);
         } else if (f.includes('package.json')) {
-            const content = e?.content.toString();
+            const content = t.read(`./${f}`)?.toString();
             if (typeof content === 'string') {
                 if (content.includes('"jasmine-core"')) {
                     found.jasmine.push(f);


### PR DESCRIPTION
-only detect jest/jasmine via the root folder (don't use tree.visit as that reads ALL files and takes a lot of time)